### PR TITLE
Initial commit for calib pattern manual verify feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,9 @@ ENV/
 .spyderproject
 .spyproject
 
+# PyCharm project settings
+.idea
+
 # Rope project settings
 .ropeproject
 

--- a/anipose/anipose.py
+++ b/anipose/anipose.py
@@ -14,6 +14,9 @@ DEFAULT_CONFIG = {
         'calibration_init': None,
         'fisheye': False
     },
+    'manual_verification': {
+        'manually_verify': False
+    },
     'triangulation': {
         'ransac': False,
         'optim': False,

--- a/anipose/common.py
+++ b/anipose/common.py
@@ -191,6 +191,7 @@ def get_calibration_board(config):
 
     board_size = calib['board_size']
     board_type = calib['board_type'].lower()
+    manually_verify = calib['manually_verify']
 
     if board_type == 'aruco':
         raise NotImplementedError("aruco board is not implemented with the current pipeline")
@@ -200,10 +201,14 @@ def get_calibration_board(config):
             calib['board_square_side_length'],
             calib['board_marker_length'],
             calib['board_marker_bits'],
-            calib['board_marker_dict_number'])
+            calib['board_marker_dict_number'],
+            manually_verify=manually_verify)
+
+
+
     elif board_type == 'checkerboard':
         board = Checkerboard(board_size[0], board_size[1],
-                             calib['board_square_side_length'])
+                             calib['board_square_side_length'], manually_verify=manually_verify)
     else:
         raise ValueError("board_type should be one of "
                          "'aruco', 'charuco', or 'checkerboard' not '{}'".format(

--- a/anipose/common.py
+++ b/anipose/common.py
@@ -187,11 +187,13 @@ def find_calibration_folder(config, session_path):
 
 
 def get_calibration_board(config):
-    calib = config['calibration']
 
+    calib = config['calibration']
     board_size = calib['board_size']
     board_type = calib['board_type'].lower()
-    manually_verify = calib['manually_verify']
+
+    manual_verification = config['manual_verification']
+    manually_verify = manual_verification['manually_verify']
 
     if board_type == 'aruco':
         raise NotImplementedError("aruco board is not implemented with the current pipeline")

--- a/docs/start_3d.md
+++ b/docs/start_3d.md
@@ -91,6 +91,7 @@ What to configure:
 - Length of marker separation (for aruco) or square side (for charuco or checkerboard) (triangulation is set to this unit)
 - Length of marker side in appropriate unit, in same unit as above
 - aruco marker dictionary (number of bits and number of markers in dictionary)
+- Boolean value indicating whether or not you want to manually verify the detection of the calibration pattern in each frame (Allows you to throw out bad detections)
 
 An example configuration:
 ```toml
@@ -115,6 +116,10 @@ board_marker_length = 3 # mm
 
 # If charuco or checkerboard, square side length
 board_square_side_length = 4 # mm
+
+# Whether or not you want to manually verify the calibration marker detection
+manually_verify = false
+
 ```
 
 ## Drawing the calibration board

--- a/docs/start_3d.md
+++ b/docs/start_3d.md
@@ -91,7 +91,6 @@ What to configure:
 - Length of marker separation (for aruco) or square side (for charuco or checkerboard) (triangulation is set to this unit)
 - Length of marker side in appropriate unit, in same unit as above
 - aruco marker dictionary (number of bits and number of markers in dictionary)
-- Boolean value indicating whether or not you want to manually verify the detection of the calibration pattern in each frame (Allows you to throw out bad detections)
 
 An example configuration:
 ```toml
@@ -117,9 +116,22 @@ board_marker_length = 3 # mm
 # If charuco or checkerboard, square side length
 board_square_side_length = 4 # mm
 
-# Whether or not you want to manually verify the calibration marker detection
-manually_verify = false
 
+```
+
+## Manual verification of calibration pattern detection
+
+The automatic calibration pattern detection can fail. Removing incorrectly detected frames will improve calibration accuracy. 
+
+What to configure:
+- Optional boolean (default=false) indicating whether or not you want to manually verify the detection of the calibration pattern in each frame (Allows you to throw out bad detections)
+
+To manually verify, add the example below to your config.toml file.
+
+```toml
+[manual_verification]
+# true / false
+manually_verify = true
 ```
 
 ## Drawing the calibration board


### PR DESCRIPTION
Proposed addition to allow anipose to use the calligator "Manually verify calibration pattern detection" feature. The change would allow users to define a boolean "manually_verify" in the calibration section of their config.toml file which would toggle the feature on or off. 