### PR TITLE
fixing setup.py version requirement for opencv, changes in 4.7.X break anipose

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setuptools.setup(
     install_requires=[
         'deeplabcut>=2.0.4.1',
         'aniposelib>=0.4.3',
-        'opencv-contrib-python',
+        'opencv-python<=4.6.0.66',
+        'opencv-contrib-python<=4.6.0.66',
         'toml',
         'numpy',
         'scipy',


### PR DESCRIPTION
[This Stack Overflow post ](https://stackoverflow.com/questions/75085270/cv2-aruco-charucoboard-create-not-found-in-opencv-4-7-0) describes the issue and error message received using `anipose calibrate`. I've just added a version requirement for both `opencv-python` and `opencv-contrib-python`, however, I did test correcting the syntax at line 567 from:
```
self.board = aruco.CharucoBoard_create(squaresX, squaresY,
                                               square_length, marker_length,
                                               self.dictionary)
```
to:
```
self.board = aruco.CharucoBoard((squaresX, squaresY), # make a tuple
                                               square_length, marker_length,
                                               self.dictionary)
```

and line 610 from:
`params = aruco.DetectorParameters_create()`
to:
`params = aruco.DetectorParameters()`

which is an alternative method to resolve this new error. Hope that helps!