### PR TITLE
Add start and end params for video creation

### DIFF
--- a/anipose/anipose.py
+++ b/anipose/anipose.py
@@ -258,9 +258,15 @@ def label_2d_filter(config):
     label_videos_filtered_all(config)
 
 @cli.command()
+@click.option('--start', default=None, type=str, 
+              help='Start time: timestamp (00:00:05) or fraction (0.1)')
+@click.option('--end', default=None, type=str, 
+              help='End time: timestamp (00:01:30) or fraction (0.9)')
 @pass_config
-def label_3d(config):
+def label_3d(config, start, end):
     from .label_videos_3d import label_videos_3d_all
+    from .common import parse_range
+    config['export_range'] = parse_range(start, end)
     click.echo('Labeling videos in 3D...')
     label_videos_3d_all(config)
 
@@ -272,9 +278,15 @@ def label_3d_filter(config):
     label_videos_3d_filtered_all(config)
 
 @cli.command()
+@click.option('--start', default=None, type=str, 
+              help='Start time: timestamp (00:00:05) or fraction (0.1)')
+@click.option('--end', default=None, type=str, 
+              help='End time: timestamp (00:01:30) or fraction (0.9)')
 @pass_config
-def label_combined(config):
+def label_combined(config, start, end):
     from .label_combined import label_combined_all
+    from .common import parse_range
+    config['export_range'] = parse_range(start, end)
     click.echo('Labeling combined videos...')
     label_combined_all(config)
 

--- a/anipose/label_videos_3d.py
+++ b/anipose/label_videos_3d.py
@@ -15,8 +15,10 @@ import sys
 from collections import defaultdict
 from matplotlib.pyplot import get_cmap
 
-from .common import make_process_fun, get_nframes, get_video_name, get_video_params, get_data_length, natural_keys
-
+from .common import (
+    make_process_fun, get_nframes, get_video_name, get_video_params, 
+    get_data_length, natural_keys, get_frame_range,
+)
 
 def connect(points, bps, bp_dict, color):
     ixs = [bp_dict[bp] for bp in bps]
@@ -129,7 +131,12 @@ def visualize_labels(config, labels_fname, outname, fps=300):
 
     mlab.view(focalpoint='auto', distance='auto')
 
-    for framenum in trange(data.shape[0], ncols=70):
+    nframes = data.shape[0]
+    start_frame_num, end_frame_num = get_frame_range(config, nframes, fps)
+    if (end_frame_num - start_frame_num) != nframes:
+        print(f'Exporting with frame range {start_frame_num} to {end_frame_num} out of {nframes}')
+    
+    for framenum in trange(start_frame_num, end_frame_num, ncols=70):
         fig.scene.disable_render = True
 
         if framenum in framedict:


### PR DESCRIPTION
Add `--start` and `--end` params for `label-3d` and `label-combined`, so that one can make shorter videos for quick quality check.